### PR TITLE
Hiding delete message feature.

### DIFF
--- a/aalto_fuksi_bot/bot_main.py
+++ b/aalto_fuksi_bot/bot_main.py
@@ -381,7 +381,7 @@ async def canteens(update: Update, context: ContextTypes.DEFAULT_TYPE):
     # remove the command message sent by the user
     if not update.message:
         return
-    await context.bot.delete_message(update.message.chat_id, update.message.id)
+    # await context.bot.delete_message(update.message.chat_id, update.message.id)
 
     options = ["Link", "Menu", "Opening Hours", "Cancel"]
     keyboard = [


### PR DESCRIPTION
The is a bug in the production code where the bot is unable to locate the command message that the user send and therefore cannot delete it.

In this update, this feature will be hidden (commented out) as it is not required. Any future update might fix this bug.